### PR TITLE
New feat ignore train types

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Go to Configuration -> Integrations and click on "add integration". Then search 
 - **station**: The name of the station to be tracked.
   - **IRIS-TTS** (default): Please check your station at [dbf.finalrewind.org](https://dbf.finalrewind.org/) if it is working.
 - **next_departures** (optional): The number of upcoming departures to display. Default is 4, but you can adjust it according to your preferences.
-- **update_interval** (optional): The time interval (in minutes) at which the integration will fetch updated departure data. Default is 3 minutes.
+- **update_interval** (optional): The time interval (in minutes) at which the integration will fetch updated departure data. Default is 3 minutes, minimum is 1 minute (data wont be refreshed more often in the backend).
 - **hide_low_delay** (optional): If enabled, departures with a delay of less than 5 minutes will be hidden. Default is false.
 - **detailed** (optional): If enabled, additional details about the departures will be shown. Default is false.
 - **past_60_minutes** (optional): If enabled, shows departures from the past 60 minutes. Default is false.
@@ -57,6 +57,8 @@ Go to Configuration -> Integrations and click on "add integration". Then search 
   - **departure**: Only shows departure times.
 - **platforms** (optional): If your station has multiple platforms and you want to filter by a specific platform, you can use this setting. Enter the platform(s) as a comma-separated list (e.g., `1, 2, 3`). This will ensure that the integration fetches data only for the specified platforms. If left empty, data for all platforms will be shown.
 
+
+Note: You are limited to adding 30 sensors, if you are not using a custom_api_url.
 
 ## Accessing the data
 

--- a/custom_components/db_infoscreen/config_flow.py
+++ b/custom_components/db_infoscreen/config_flow.py
@@ -24,14 +24,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            existing_entries = self.hass.config_entries.async_entries(DOMAIN)
-            if len(existing_entries) >= MAX_SENSORS:
-                errors["base"] = "max_sensors_reached"
-                return self.async_show_form(
-                    step_id="user",
-                    data_schema=self.data_schema(),
-                    errors=errors
-                )
+            # Check if CONF_CUSTOM_API_URL is empty before checking MAX_SENSORS
+            custom_api_url = user_input.get(CONF_CUSTOM_API_URL, "")
+            if not custom_api_url:
+                existing_entries = self.hass.config_entries.async_entries(DOMAIN)
+                if len(existing_entries) >= MAX_SENSORS:
+                    errors["base"] = "max_sensors_reached"
+                    return self.async_show_form(
+                        step_id="user",
+                        data_schema=self.data_schema(),
+                        errors=errors
+                    )
 
             unique_id = user_input[CONF_STATION]
             await self.async_set_unique_id(unique_id)

--- a/custom_components/db_infoscreen/config_flow.py
+++ b/custom_components/db_infoscreen/config_flow.py
@@ -8,7 +8,7 @@ from .const import (
     DOMAIN, CONF_STATION, CONF_NEXT_DEPARTURES, CONF_UPDATE_INTERVAL,
     DEFAULT_NEXT_DEPARTURES, DEFAULT_UPDATE_INTERVAL, DEFAULT_OFFSET, MAX_SENSORS,
     CONF_HIDE_LOW_DELAY, CONF_DETAILED, CONF_PAST_60_MINUTES, CONF_CUSTOM_API_URL, 
-    CONF_DATA_SOURCE, CONF_OFFSET, CONF_PLATFORMS, CONF_ADMODE
+    CONF_DATA_SOURCE, CONF_OFFSET, CONF_PLATFORMS, CONF_ADMODE, CONF_IGNORED_PRODUCTS, CONF_IGNORED_PRODUCTS_OPTIONS
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,6 +66,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_OFFSET, default=DEFAULT_OFFSET): cv.string,
                 vol.Optional(CONF_PLATFORMS, default=""): cv.string,
                 vol.Optional(CONF_ADMODE, default="preferred departure"): vol.In(["preferred departure", "arrival", "departure"]),
+                vol.Optional(CONF_IGNORED_PRODUCTS, default=[]): vol.All(
+                    cv.ensure_list, 
+                    vol.Unique(), 
+                    vol.Length(min=0, max=len(CONF_IGNORED_PRODUCTS_OPTIONS))
+                ),
             }
         )
 
@@ -107,6 +112,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(CONF_OFFSET, default=current_options.get(CONF_OFFSET, DEFAULT_OFFSET)): cv.string,
                     vol.Optional(CONF_PLATFORMS, default=current_options.get(CONF_PLATFORMS, "")): cv.string,
                     vol.Optional(CONF_ADMODE, default="preferred departure"): vol.In(["preferred departure", "arrival", "departure"]),
+                    vol.Optional(CONF_IGNORED_PRODUCTS, default=[]): vol.All(
+                        cv.ensure_list, 
+                        vol.Unique(), 
+                        vol.Length(min=0, max=len(CONF_IGNORED_PRODUCTS_OPTIONS))
+                    ),
                 }
             ),
+            options=user_input
         )

--- a/custom_components/db_infoscreen/const.py
+++ b/custom_components/db_infoscreen/const.py
@@ -17,3 +17,16 @@ CONF_OFFSET = "offset"
 DEFAULT_OFFSET = "00:00"
 CONF_PLATFORMS = "platforms"
 CONF_ADMODE = "admode"
+
+CONF_IGNORED_PRODUCTS = "ignored_products"
+CONF_IGNORED_PRODUCTS_OPTIONS = {
+    "BUS": "Busverkehr (BUS)",
+    "STR": "Straßenbahn (STR)",
+    "S": "Stadtbahn (S-Bahn)",
+    "RE": "Regional Express (RE)",
+    "RB": "Regional Bahn (RB)",
+    "EC": "EuroCity (EC)",
+    "IC": "Intercity (IC)",
+    "ICE": "Intercity Express (ICE)",
+    "BRB": "Bayrische Regionalbahn"
+}

--- a/custom_components/db_infoscreen/const.py
+++ b/custom_components/db_infoscreen/const.py
@@ -1,5 +1,4 @@
 DOMAIN = "db_infoscreen"
-ATTRIBUTION = "Data provided by dbf.finalrewind.org api"
 
 CONF_STATION = "station"
 CONF_NEXT_DEPARTURES = "next_departures"

--- a/custom_components/db_infoscreen/sensor.py
+++ b/custom_components/db_infoscreen/sensor.py
@@ -1,5 +1,5 @@
 from homeassistant.components.sensor import SensorEntity
-from .const import DOMAIN
+from .const import DOMAIN, CONF_CUSTOM_API_URL
 import logging
 from datetime import datetime
 
@@ -27,10 +27,13 @@ class DBInfoSensor(SensorEntity):
 
     @property
     def extra_state_attributes(self):
+        custom_api_url = self.coordinator.config_entry.data.get(CONF_CUSTOM_API_URL, "")
+        attribution = f"Data provided by {custom_api_url}" if custom_api_url else "Data provided by dbf.finalrewind.org API"
         return {
             "next_departures": self.coordinator.data or [],
             "station": self.station,
             "last_updated": self.coordinator.last_update.isoformat() if self.coordinator.last_update else "Unknown",
+            "attribution": attribution,
         }
 
     @property

--- a/custom_components/db_infoscreen/strings.json
+++ b/custom_components/db_infoscreen/strings.json
@@ -16,7 +16,8 @@
           "data_source": "Data Source",
           "offset": "Offset Time",
           "admode": "Display Mode",
-          "platforms": "Platforms"
+          "platforms": "Platforms",
+          "ignored_products": "Ignored train types"
         }
       }
     },
@@ -44,7 +45,8 @@
           "data_source": "Data Source",
           "offset": "Offset Time",
           "admode": "Display Mode",
-          "platforms": "Platforms"
+          "platforms": "Platforms",
+          "ignored_products": "Ignored train types"
         }
       }
     }

--- a/custom_components/db_infoscreen/translations/de.json
+++ b/custom_components/db_infoscreen/translations/de.json
@@ -16,7 +16,8 @@
           "data_source": "Datenquelle",
           "offset": "Offset-Zeit",
           "admode": "Bevorzugte Zeitdarstellung (Abfahrt / Ankunft)",
-          "platforms": "Gleise"
+          "platforms": "Gleise",
+          "ignored_products": "Zugarten ignorieren"
         }
       }
     },
@@ -44,7 +45,8 @@
           "data_source": "Datenquelle",
           "offset": "Offset-Zeit",
           "admode": "Bevorzugte Zeitdarstellung (Abfahrt / Ankunft)",
-          "platforms": "Gleise"
+          "platforms": "Gleise",
+          "ignored_products": "Zugarten ignorieren"
         }
       }
     }

--- a/custom_components/db_infoscreen/translations/en.json
+++ b/custom_components/db_infoscreen/translations/en.json
@@ -16,7 +16,8 @@
           "data_source": "Data Source",
           "offset": "Offset Time",
           "admode": "Display Mode",
-          "platforms": "Platforms"
+          "platforms": "Platforms",
+          "ignored_products": "Ignored train types"
         }
       }
     },
@@ -44,7 +45,8 @@
           "data_source": "Data Source",
           "offset": "Offset Time",
           "admode": "Display Mode",
-          "platforms": "Platforms"
+          "platforms": "Platforms",
+          "ignored_products": "Ignored train types"
         }
       }
     }


### PR DESCRIPTION
# Proposed Changes

The goal is to bring back the functionality "products to ignore" from ha-deutschebahn: https://github.com/FaserF/ha-deutschebahn?tab=readme-ov-file#configuration-variables

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
