### PR TITLE
show trains after midnight next day

### DIFF
--- a/custom_components/db_infoscreen/__init__.py
+++ b/custom_components/db_infoscreen/__init__.py
@@ -192,11 +192,16 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator):
                             except ValueError:
                                 try:
                                     # Fallback to assuming time format HH:MM if the previous format doesn't work
-                                    departure_time = datetime.strptime(departure_time, "%H:%M").replace(
-                                        year=datetime.now().year,
-                                        month=datetime.now().month,
-                                        day=datetime.now().day,
+                                    now = datetime.now()
+                                    departure_time_candidate = datetime.strptime(departure_time, "%H:%M").replace(
+                                        year=now.year,
+                                        month=now.month,
+                                        day=now.day,
                                     )
+                                    # If the time is before now (already passed today), treat as next day
+                                    if departure_time_candidate < now:
+                                        departure_time_candidate = departure_time_candidate + timedelta(days=1)
+                                    departure_time = departure_time_candidate
                                 except ValueError:
                                     _LOGGER.error("Invalid time format: %s", departure_time)
                                     continue


### PR DESCRIPTION
With this fix the sensors will also show trains after midnight - otherwise the list empties out after 23:00.

# Proposed Changes

My private departure monitor was not showing trains after midnight on the next day. So the list became smaller and smaller after 23:00 and was always completely empty shortly before midnight. Right after midnight the "missing" trains were then shown.

## Related Issues

[Bug]: Trains after midnight are not shown (https://github.com/FaserF/ha-db_infoscreen/issues/50)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Ensures time-only departures (HH:MM) that have already passed today are scheduled for the next day, preventing past departures from appearing.
  - Improves accuracy of upcoming departures around midnight and late-night scenarios.
  - Continues to safely skip invalid time formats, reducing potential disruptions on the info screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->