### PR TITLE
fix reconfigure flow by not setting config_entry explicitly

### DIFF
--- a/custom_components/db_infoscreen/config_flow.py
+++ b/custom_components/db_infoscreen/config_flow.py
@@ -131,7 +131,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     def async_get_options_flow(config_entry):
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
     def data_schema(self):
         """
@@ -168,9 +168,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    def __init__(self, config_entry):
-        self.config_entry = config_entry
-
     async def async_step_init(self, user_input=None):
         """
         Handle the options flow initial step for the integration.


### PR DESCRIPTION
# Proposed Changes

Setting config_entry has been deprecated for a while and stopped working in 2025.12.0, this just removes the code that does it, it is not necessary anymore. 

## Related Issues

Fixes #74 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal configuration handler architecture to reduce unnecessary dependencies and improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->