### PR TITLE
Throttle API fetches after 429 responses

### DIFF
--- a/custom_components/db_infoscreen/__init__.py
+++ b/custom_components/db_infoscreen/__init__.py
@@ -674,12 +674,9 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if self.server_version is None:
             await self.async_fetch_server_version()
 
-        do_api_fetch = False
-        if (
-            self._raw_api_data is None
-            or now.timestamp() - self._last_api_fetch >= self._api_update_interval
-        ):
-            do_api_fetch = True
+        do_api_fetch = (
+            now.timestamp() - self._last_api_fetch >= self._api_update_interval
+        )
 
         if not do_api_fetch:
             _LOGGER.debug(
@@ -690,6 +687,8 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 ),
             )
             data = self._raw_api_data
+            if data is None:
+                return self._last_valid_value or []
         elif self.fetch_url in RESPONSE_CACHE:
             timestamp, cached_data = RESPONSE_CACHE[self.fetch_url]
             if now - timestamp < CACHE_TTL:
@@ -717,6 +716,7 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                         self.fetch_url, timeout=aiohttp.ClientTimeout(total=30)
                     ) as response:
                         if response.status == 429:
+                            self._last_api_fetch = now.timestamp()
                             _LOGGER.warning(
                                 "Rate limit hit for %s (429 Too Many Requests). Skipping retries for this cycle.",
                                 self.fetch_url,
@@ -736,6 +736,7 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                         break  # Success, exit retry loop
                 except aiohttp.ClientResponseError as err:
                     if err.status == 429:
+                        self._last_api_fetch = now.timestamp()
                         _LOGGER.warning(
                             "Rate limit hit for %s (429 Too Many Requests). skipping retries.",
                             self.fetch_url,

--- a/custom_components/db_infoscreen/__init__.py
+++ b/custom_components/db_infoscreen/__init__.py
@@ -738,7 +738,7 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     if err.status == 429:
                         self._last_api_fetch = now.timestamp()
                         _LOGGER.warning(
-                            "Rate limit hit for %s (429 Too Many Requests). skipping retries.",
+                            "Rate limit hit for %s (429 Too Many Requests). Skipping retries.",
                             self.fetch_url,
                         )
                         return self._last_valid_value or []

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -22,19 +22,9 @@ def _mock_response(status=200, data=None):
     """Create a minimal async context manager response."""
     resp = MagicMock()
     resp.status = status
-
-    async def json_func():
-        return data if data is not None else {}
-
-    async def enter_func():
-        return resp
-
-    async def exit_func(exc_type, exc, tb):
-        return None
-
-    resp.json = MagicMock(side_effect=json_func)
-    resp.__aenter__ = MagicMock(side_effect=enter_func)
-    resp.__aexit__ = MagicMock(side_effect=exit_func)
+    resp.json = AsyncMock(return_value=data if data is not None else {})
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=None)
     return resp
 
 
@@ -158,6 +148,7 @@ async def test_coordinator_missing_raw_data_without_fetch_returns_last_valid(
     """Test that throttled local ticks do not fetch again without raw cache data."""
     coordinator = DBInfoScreenCoordinator(hass, mock_config_entry)
     coordinator.server_version = "test"
+    coordinator._api_update_interval = 60
     coordinator._last_api_fetch = dt_util.now().timestamp()
     coordinator._raw_api_data = None
     coordinator._last_valid_value = [{"destination": "Cached Dest"}]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,6 +18,26 @@ from custom_components.db_infoscreen.const import (
 from tests.common import patch_session
 
 
+def _mock_response(status=200, data=None):
+    """Create a minimal async context manager response."""
+    resp = MagicMock()
+    resp.status = status
+
+    async def json_func():
+        return data if data is not None else {}
+
+    async def enter_func():
+        return resp
+
+    async def exit_func(exc_type, exc, tb):
+        return None
+
+    resp.json = MagicMock(side_effect=json_func)
+    resp.__aenter__ = MagicMock(side_effect=enter_func)
+    resp.__aexit__ = MagicMock(side_effect=exit_func)
+    return resp
+
+
 @pytest.fixture(autouse=True)
 def patch_coordinator():
     """Patch DataUpdateCoordinator to prevent background tasks and simplify tests."""
@@ -115,6 +135,39 @@ async def test_coordinator_update_data(hass, mock_config_entry):
         data = await coordinator._async_update_data()
         assert len(data) == 1
         assert data[0]["destination"] == "Test Dest"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_429_counts_as_api_fetch(hass, mock_config_entry):
+    """Test that 429 responses throttle the next local update tick."""
+    coordinator = DBInfoScreenCoordinator(hass, mock_config_entry)
+    coordinator.server_version = "test"
+    coordinator._last_valid_value = [{"destination": "Cached Dest"}]
+
+    with patch_session(side_effect=lambda *_args, **_kwargs: _mock_response(429)):
+        data = await coordinator._async_update_data()
+
+    assert data == [{"destination": "Cached Dest"}]
+    assert coordinator._last_api_fetch > 0
+
+
+@pytest.mark.asyncio
+async def test_coordinator_missing_raw_data_without_fetch_returns_last_valid(
+    hass, mock_config_entry
+):
+    """Test that throttled local ticks do not fetch again without raw cache data."""
+    coordinator = DBInfoScreenCoordinator(hass, mock_config_entry)
+    coordinator.server_version = "test"
+    coordinator._last_api_fetch = dt_util.now().timestamp()
+    coordinator._raw_api_data = None
+    coordinator._last_valid_value = [{"destination": "Cached Dest"}]
+
+    with patch_session(
+        side_effect=lambda *_args, **_kwargs: pytest.fail("Unexpected API fetch")
+    ):
+        data = await coordinator._async_update_data()
+
+    assert data == [{"destination": "Cached Dest"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

I kept running into `429 Too Many Requests` responses from the DB API. While looking into it, I noticed that this case was not really handled as part of the existing retry/fetch logic.

When the API returned `429`, the failed request was not counted as an API fetch attempt. As a result, the coordinator could immediately try to fetch again on the next update cycle, even though the API had just indicated that it was being rate limited.

This change treats a `429` response as a completed fetch attempt for throttling purposes. That way, the existing fetch interval is respected after hitting the rate limit, and the integration avoids sending another request right away. It also falls back to the last valid value if no raw API data is available during a throttled update cycle, so the infoscreen can keep showing useful data.

## Changes

- Handle `429 Too Many Requests` as part of the fetch throttling logic.
- Update the last API fetch timestamp after a `429` response.
- Fall back to the last valid data when an update is throttled and no raw API data is available.
- Add tests for the `429` handling and missing raw-data fallback behavior.

## Why?

This avoids repeated requests after the DB API has already rate limited the integration. It should make the integration behave more politely toward the API and keep the infoscreen more stable when fresh data cannot be fetched temporarily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API rate-limiting to prevent data loss when requests are throttled; coordinator records the fetch attempt and returns cached results instead of failing.
  * Coordinator now reliably returns the last valid cached data when fresh API data is unavailable, avoiding empty or None results during transient issues.

* **Tests**
  * Added unit tests covering rate-limiting and missing-data scenarios to ensure correct cached-result behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->