### PR TITLE
fix(coordinator): raise UpdateFailed instead of caching empty no_data

### DIFF
--- a/custom_components/db_infoscreen/__init__.py
+++ b/custom_components/db_infoscreen/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.network import get_url
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
@@ -754,7 +754,11 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                                 "Rate limit hit for %s (429 Too Many Requests). Skipping retries for this cycle.",
                                 self.fetch_url,
                             )
-                            return self._last_valid_value or []
+                            if self._last_valid_value:
+                                return self._last_valid_value
+                            raise UpdateFailed(
+                                f"Rate limited (429) while fetching {self.fetch_url}"
+                            )
 
                         response.raise_for_status()
                         data = await response.json()
@@ -775,7 +779,11 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                             "Rate limit hit for %s (429 Too Many Requests). Skipping retries.",
                             self.fetch_url,
                         )
-                        return self._last_valid_value or []
+                        if self._last_valid_value:
+                            return self._last_valid_value
+                        raise UpdateFailed(
+                            f"Rate limited (429) while fetching {self.fetch_url}"
+                        )
                     if attempt < max_retries:
                         _LOGGER.warning(
                             "Attempt %d failed fetching data from %s: %s. Retrying in %d seconds...",
@@ -795,7 +803,14 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                         )
                         # Activate Repairs issue
                         self._handle_update_error(str(err))
-                        return self._last_valid_value or []
+                        # Throttle the next API fetch so repeated failures respect
+                        # the configured interval instead of hammering the server.
+                        self._last_api_fetch = now.timestamp()
+                        if self._last_valid_value:
+                            return self._last_valid_value
+                        raise UpdateFailed(
+                            f"Failed to fetch data from {self.fetch_url}: {err}"
+                        )
                 except (
                     asyncio.TimeoutError,
                     aiohttp.ClientError,
@@ -821,11 +836,20 @@ class DBInfoScreenCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                         )
                         # Activate Repairs issue
                         self._handle_update_error(str(err))
-                        return self._last_valid_value or []
+                        # Throttle the next API fetch so repeated failures respect
+                        # the configured interval instead of hammering the server.
+                        self._last_api_fetch = now.timestamp()
+                        if self._last_valid_value:
+                            return self._last_valid_value
+                        raise UpdateFailed(
+                            f"Failed to fetch data from {self.fetch_url}: {err}"
+                        )
 
         if not isinstance(data, dict):
             _LOGGER.error("Expected dict from API, got %s", type(data))
-            return self._last_valid_value or []
+            if self._last_valid_value:
+                return self._last_valid_value
+            raise UpdateFailed(f"Expected dict from API, got {type(data)}")
 
         raw_departures = data.get("departures", [])
         if raw_departures is None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -166,6 +166,29 @@ async def test_coordinator_429_exception_counts_as_api_fetch(hass, mock_config_e
 
 
 @pytest.mark.asyncio
+async def test_coordinator_429_without_cache_raises_updatefailed(
+    hass, mock_config_entry
+):
+    """A 429 with no previously cached data must fail the update.
+
+    Regression: previously this returned an empty list that the coordinator
+    treated as a *successful* update, leaving sensors stuck at ``no_data``
+    (e.g. after a restart while the shared User-Agent is rate limited).
+    """
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    coordinator = DBInfoScreenCoordinator(hass, mock_config_entry)
+    coordinator.server_version = "test"
+
+    with patch_session(side_effect=lambda *_args, **_kwargs: _mock_response(429)):
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    # The next fetch is still throttled so failures don't hammer the server.
+    assert coordinator._last_api_fetch > 0
+
+
+@pytest.mark.asyncio
 async def test_coordinator_missing_raw_data_without_fetch_returns_last_valid(
     hass, mock_config_entry
 ):


### PR DESCRIPTION
## Problem
On a `429` / HTTP error / network error with no previously cached data (e.g. right after a restart), `_async_update_data()` returned `self._last_valid_value or []`. `DataUpdateCoordinator` treats the empty list as a **successful** update, so sensors get stuck at `no_data` with `last_update_success = True`, hiding the outage and preventing self-recovery.

This is easy to hit in practice: the public API rate-limits by `User-Agent`, and the shared integration UA is frequently throttled — the exact same request with a different UA returns `200`.

## Change
- Raise `UpdateFailed` on 429 / exhausted retries / non-dict responses **when there is no cached value to fall back on**. When cached data exists, behaviour is unchanged (last known departures are kept).
- Set `_last_api_fetch` on the network-error paths so repeated failures respect the configured `update_interval` instead of re-hitting the API on every coordinator tick.

## Tests
- Existing 429 tests (which pre-seed `_last_valid_value`) pass unchanged.
- Added `test_coordinator_429_without_cache_raises_updatefailed`.

> Note: I couldn't run the full suite locally (only Python 3.10 available here; HA 2026 needs ≥3.12) — relying on CI.

Fixes #180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API rate limits and failed updates.
  * Preserves the most recent valid departure data when temporary errors occur.
  * Clearly reports update failures when no cached data is available.
  * Prevents immediate repeated requests after rate limiting or failed fetches.
  * Detects and reports unexpected API response formats.

* **Tests**
  * Added coverage for rate-limit failures when no cached data exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->